### PR TITLE
The Battle for Wesnoth doesn't use Emacs Lisp

### DIFF
--- a/games/m.yaml
+++ b/games/m.yaml
@@ -221,7 +221,7 @@
     url: https://www.wesnoth.org/
     repo: http://wiki.wesnoth.org/WesnothRepository
     development: active
-    lang: [C++, C, Java, Python, Lua, Emacs Lisp]
+    lang: [C++, C, Java, Python, Lua]
     license: [GPL2]
     updated: 2016-01-01
     images:


### PR DESCRIPTION
While it is listed on the GitHub repository, upon closer inspection, you can see the only files written in Lisp are Emacs modes intended for editing game data (or something along those lines). It isn't actually used in the game.